### PR TITLE
New emoji are not all working properly

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -49,4 +49,8 @@ describe('apple-color-emoji', function() {
     assert.equal(emoji.getImage('🏃🏾‍♀️'), emoji.basePath + '/d83c-dfc3-d83c-dffe-2640.png');
     assert.equal(emoji.getImage('🏃🏿‍♀️'), emoji.basePath + '/d83c-dfc3-d83c-dfff-2640.png');
   });
+
+  it("supports new zero width joiner emoji", function () {
+    assert.equal(emoji.getImage('👨🏻‍⚕️'), emoji.basePath + '/d83c-dfc3-2640.png'); //FIXME this path is not quite right.
+  });
 });


### PR DESCRIPTION
Note: I didn't actually use the correct path in this test, but currently `emoji.getImage` returns null for many of the new emoji. 